### PR TITLE
Add markdownlint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.5.0
+    steps:
+      - checkout
+      - run:
+          name: "Install markdownlint-cli"
+          command: |
+              sudo npm install -g markdownlint-cli
+      - run:
+          name: "Check with markdownlint"
+          command: |
+              echo -n "markdownlint version: "
+              markdownlint --version
+              markdownlint ./
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,16 @@
+---
+# Rules https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md
+default: true
+list-marker-space: false
+line-length: false
+MD004:
+  style: dash
+MD003:
+  style: atx
+MD007:
+  indent: 2
+MD024:
+  allow_different_nesting: true
+MD033:
+  allowed_elements:
+  - pre


### PR DESCRIPTION
Since this repo will hold documents written in markdown similar to the [upp-docs][upp-docs] repo it will be nice to check the markdown style.

[upp-docs]: https://github.com/Financial-Times/upp-docs