### PR TITLE
Enable the linter for unused parameters

### DIFF
--- a/golangci-config/.golangci.yml
+++ b/golangci-config/.golangci.yml
@@ -30,6 +30,7 @@ linters:
     - structcheck
     - stylecheck
     - typecheck
+    - unparam
     - unused
     - varcheck
     - whitespace


### PR DESCRIPTION
# Description

## What

Enable `unparam` that reports unused function parameters

## Why

Our linter configuration allows unused code and we want to avoid this

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
